### PR TITLE
Image change and small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ sqlite
 *.db
 *.bak
 CoffeeDB.db
+static/images/

--- a/SnackBar.py
+++ b/SnackBar.py
@@ -41,7 +41,8 @@ app.config['DEBUG'] = False
 
 db = SQLAlchemy(app)
 
-
+if not os.path.exists(app.config['IMAGE_FOLDER']):
+    os.makedirs(app.config['IMAGE_FOLDER'])
 
 def settingsFor(key):
     dbEntry = db.session.query(settings).filter_by(key=key).first()

--- a/SnackBar.py
+++ b/SnackBar.py
@@ -38,7 +38,6 @@ app.config['IMAGE_FOLDER'] = 'static/images'
 app.config['ICON_FOLDER'] = 'static/icons'
 app.config['DEBUG'] = False
 
-
 db = SQLAlchemy(app)
 
 if not os.path.exists(app.config['IMAGE_FOLDER']):
@@ -823,13 +822,14 @@ def userPage(userid):
 
     noUsers = user.query.filter(user.hidden != True).count()
     currbill = restBill(userid)
-
+    canChangeImage = settingsFor('usersCanChangeImage')
     return render_template('choices.html',
                            currbill = currbill,
                            chosenuser = userName,
                            userid = userid,
                            items = items,
                            noOfUsers = noUsers,
+                           canChangeImage = canChangeImage
                            )
 
 def sendEmailNewUser(curuser):
@@ -1035,6 +1035,7 @@ import time
 import threading
 from flaskrun import flaskrun
 
+
 def run_schedule():
     while 1:
         schedule.run_pending()
@@ -1053,5 +1054,6 @@ if __name__ == "__main__":
     # app.run()
     #app.run(host='0.0.0.0', port=5000, debug=False)
     flaskrun(app)
+
 
 

--- a/SnackBar.py
+++ b/SnackBar.py
@@ -931,7 +931,25 @@ def analysis():
     content, tagsHoursLabels = main()
     return render_template('analysis.html', content = content, tagsHoursLabels = tagsHoursLabels)
 
+@app.route('/changeImage', methods=(['POST']))
+def changeImage():
+	with app.app_context():
+		filename = ''
+		if 'image' in request.files:
+			file = request.files['image']
+			if file.filename != '' and allowed_file(file.filename):
+				filename = secure_filename(file.filename)
+				fullPath = os.path.join(app.config['IMAGE_FOLDER'], filename)
+				file.save(fullPath)
 
+				userid = request.form["userid"]
+				currentUser = user.query.get(userid)
+				currentUser.imageName = filename
+
+				db.session.commit()
+
+	return redirect(url_for('initial'))
+    
 def build_sample_db():
     db.drop_all()
     db.create_all()

--- a/defaultSettings.csv
+++ b/defaultSettings.csv
@@ -3,3 +3,4 @@ snackAdmin,Clemens Putschli (C5-315)
 mailSender,snackbar-noreply@fit.fraunhofer.de
 mailServer,smtp.fit.fraunhofer.de
 minimumBalance,-5
+usersCanChangeImage,true

--- a/templates/adduser.html
+++ b/templates/adduser.html
@@ -100,13 +100,7 @@
                 <label>Image</label>
                    <input type="file" name="image">
                 </div>
-
-                 Browse
-
                 <button class="ui button" type="submit">Add User</button>
-
-
-
 
   </form>
 

--- a/templates/choices.html
+++ b/templates/choices.html
@@ -129,6 +129,21 @@
             </table>
         </div>
 
+        <div class="ui divider"></div>
+
+        <div class="container ui raised segment">
+
+            <form class="ui form" method="POST" action="{{ url_for('changeImage') }}" enctype="multipart/form-data">
+            <h4 class="ui dividing header">Change Image</h4>
+            <input type="hidden" id="userid" name="userid" value="{{userid}}">
+                <div class="field">
+                <label>Image</label>
+                   <input type="file" name="image">
+                </div>
+                <button class="ui button" type="submit">Change Image</button>
+            </form>
+        </div>
+
 <script type="text/javascript">
 function idleOpenURL(timeout, url) {
     var t;

--- a/templates/choices.html
+++ b/templates/choices.html
@@ -131,7 +131,7 @@
 
         <div class="ui divider"></div>
 
-        <div class="container ui raised segment">
+        <div class="container ui raised segment" id = "changeImage">
 
             <form class="ui form" method="POST" action="{{ url_for('changeImage') }}" enctype="multipart/form-data">
             <h4 class="ui dividing header">Change Image</h4>
@@ -206,6 +206,10 @@ function buyItemNow(userid, itemid, itemName, itemPrice, confirmURL){
     return;
 }
 
+function displayChangeImage (canChangeImage) {
+    $( "#changeImage" ).toggle(canChangeImage === "true");
+}
+displayChangeImage('{{canChangeImage}}')
 idleOpenURL(20, '{{ url_for('initial') }}');
 
 </script>


### PR DESCRIPTION
This pull request add "change image" option to choices screen. It relieves the admin from the image change requests but also open to misuses. Therefore it can be deactivated with setting _usersCanChangeImage_ to "false" from the settings. 

In addition to this, it fixes 2 small things:
- "Browse" label was redundant in adduser screen.
- If images folder does not exist, adding user or changing image give internal server error. Now code checks the folder and creates it if necessary. Also added images folder to .gitignore. 